### PR TITLE
Added exponentially increasing wait time for Keybase server errors

### DIFF
--- a/src/main/java/org/keybase/NotaryApp.java
+++ b/src/main/java/org/keybase/NotaryApp.java
@@ -20,16 +20,18 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import static java.nio.file.StandardOpenOption.*;
 
 public class NotaryApp extends CatenaApp {
 
+    private static final String ISSUED_STATEMENTS_TXT = "issuedStatements.txt";
     private static final Logger log = LoggerFactory.getLogger(NotaryApp.class);
     private static ECKey chainKey;
     private static CatenaServer server;
     private static final int SECONDS_BETWEEN = 1; // waits only 1 second.
-
+    
     private static int seqno = 0;
-    private static File numberHashPairs = new File("issuedStatements.txt");
+    private static File numberHashPairs = new File(ISSUED_STATEMENTS_TXT);
 
     public static void main(String[] args) throws Exception {
         System.out.println(NotaryApp.class.getClassLoader().getResource("logging.properties"));
@@ -185,10 +187,10 @@ public class NotaryApp extends CatenaApp {
         }
 
         try {
-            Files.write(Paths.get("issuedStatements.txt"), (seq + " ").getBytes(), java.nio.file.StandardOpenOption.APPEND);
-            Files.write(Paths.get("issuedStatements.txt"), (stmt + "\n").getBytes(), java.nio.file.StandardOpenOption.APPEND);
+            Files.write(Paths.get(ISSUED_STATEMENTS_TXT), (seq + " ").getBytes(), APPEND, CREATE);
+            Files.write(Paths.get(ISSUED_STATEMENTS_TXT), (stmt + "\n").getBytes(), APPEND);
         } catch (IOException e) {
-            log.error("ERROR writing to file issuedStatmenets.txt: " + Throwables.getStackTraceAsString(e));
+            log.error("ERROR writing to file {}: {}", ISSUED_STATEMENTS_TXT, Throwables.getStackTraceAsString(e));
             System.exit(1);
         }
 
@@ -203,7 +205,7 @@ public class NotaryApp extends CatenaApp {
         int len = s.length();
         if (len % 2 == 1) {
             log.error("String of odd lenth cannot be hex.");
-            System.exit(1); // THis means there is a serious bug.
+            System.exit(1); // This means there is a serious bug.
         }
         byte[] data = new byte[len / 2];
         for (int i = 0; i < len; i += 2) {

--- a/src/main/java/org/keybase/NotaryApp.java
+++ b/src/main/java/org/keybase/NotaryApp.java
@@ -92,7 +92,7 @@ public class NotaryApp extends CatenaApp {
         }
     }
 
-    /** Waits SECONDS_BETWEEN seconds. This is called inbetween
+    /** Waits SECONDS_BETWEEN seconds. This is called in between
      * attempts to issue a new Merkle Root.
      */
     private static void waitTime() {

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+	<appender name="console" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" />
+		</layout>
+	</appender>
+
+	<logger name="org.keybase">
+		<level value="debug" />
+	</logger>
+
+	<root>
+		<level value="warn" />
+		<appender-ref ref="console" />
+	</root>
+
+</log4j:configuration>

--- a/src/test/java/org/keybase/ParseJSONTest.java
+++ b/src/test/java/org/keybase/ParseJSONTest.java
@@ -13,11 +13,11 @@ import org.slf4j.*;
 
 public class ParseJSONTest {
     private static final Logger log = LoggerFactory.getLogger(ParseJSONTest.class);
-
+    
     @Test
     /**
      * Tests JSON parser by comparing parsed Merkle Root with stored Merkle Roots
-     * with root number 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000
+     * with root number 1, 10, 100, 1000, 10000, 100000, 1000000
      */
     public void testAgainstKnown() {
         log.info("Test: Parsing JSON");
@@ -39,5 +39,7 @@ public class ParseJSONTest {
             rootNum *= 10;
         }
     }
+    
+
 
 }


### PR DESCRIPTION
In JSONParser.java, I added retry logic in the case of an error with Keybase's server (such as the server being down or returning invalid content). The wait time exponentially increases up to 10 minutes. I also made minor changes to NotaryApp.java and added log4j.xml to log  debug messages.